### PR TITLE
Remove reference numbers from main text

### DIFF
--- a/LimeSoup/NatureSoup.py
+++ b/LimeSoup/NatureSoup.py
@@ -53,6 +53,7 @@ class NatureRemoveTrash(RuleIngredient):
             # # Still deciding how to deal with removing all references,
             # # Currently all superscript references are removed.
             # {'name': 'a'}
+            {'name': 'a','data-track-action':"reference anchor"}, # FixAPR24) remove reference numbers from main text - still has brackets and commas
             {'name': 'a', 'data-track-action': 'figure anchor'},  # Figure Link
             {'name': 'a', 'data-track-action': 'supplementary material anchor'}  # Supplementary Link
         ]
@@ -145,7 +146,7 @@ class NatureCollect(RuleIngredient):
             re.compile(r'.*?acknowledge?ment.*?', re.IGNORECASE),
             re.compile(r'.*?reference.*?', re.IGNORECASE),
             re.compile(r'.*?author\s*information.*?', re.IGNORECASE),
-            re.compile(r'.*?related\s*links.*?', re.IGNORECASE),
+#            re.compile(r'.*?related\s*links.*?', re.IGNORECASE), #FixAPR24) do not remove references
             re.compile(r'.*?about\s*this\s*article.*?', re.IGNORECASE),
         ]
 
@@ -192,7 +193,10 @@ class NatureCollect(RuleIngredient):
                 'name': 'Abstract',
                 'content': [trimmed_sections[0]],
             }
+        ref = [par for par in trimmed_sections if 'reference' in par['name'].lower()] # FixAPR24) add references
+        trimmed_sections = [par for par in trimmed_sections if 'reference' not in par['name'].lower()] # FixAPR24) add references
         obj['Sections'] = trimmed_sections
+        obj['References'] = ref # FixAPR24) add references
 
         return obj
 

--- a/LimeSoup/parser/paragraphs.py
+++ b/LimeSoup/parser/paragraphs.py
@@ -57,7 +57,7 @@ def get_tag_text(cur_tag):
             strings.append('\n')
             strings.append(get_tag_text(child))
 
-    return normalize_text(''.join(strings))
+    return normalize_text(' '.join(strings)) # FixAPR24) added space between section number and heading
 
 
 def extract_paragraphs_recursive(tag_or_soup, exclude_section_rules=None):


### PR DESCRIPTION
1. Remove reference numbers from main text
2. Add References parsing separately (as a separate key 'References' with same hierarchy as 'Sections')
3. Add space between section number and section heading